### PR TITLE
Removing duration fields from waypoints examples

### DIFF
--- a/api_python/102-Movement_high_level/05-Cartesian_waypoint_trajectory.py
+++ b/api_python/102-Movement_high_level/05-Cartesian_waypoint_trajectory.py
@@ -129,12 +129,12 @@ def example_trajectory(base: BaseClient):
 
     # Array of waypoints and their information
     waypointsDefinition = (
-    (0.40, -0.10, 0.50, 0.0, kTheta_x, kTheta_y, kTheta_z), 
-    (0.50, 0.0, 0.80, 0.0, kTheta_x, kTheta_y, kTheta_z), 
-    (0.60, 0.35, 0.45, 0.0,kTheta_x, kTheta_y, kTheta_z),
+    (0.40, -0.10, 0.30, 0.0, kTheta_x, kTheta_y, kTheta_z), 
+    (0.50, 0.0, 0.40, 0.0, kTheta_x, kTheta_y, kTheta_z), 
+    (0.50, 0.35, 0.45, 0.0,kTheta_x, kTheta_y, kTheta_z),
     (0.50, -0.25, 0.30, 0.0,kTheta_x, kTheta_y, kTheta_z),
     (0.30, 0.30, 0.25, 0.0,kTheta_x, kTheta_y, kTheta_z),
-    (0.45, -0.25, 0.60, 0.0,kTheta_x, kTheta_y, kTheta_z),
+    (0.45, -0.25, 0.40, 0.0,kTheta_x, kTheta_y, kTheta_z),
     (0.35, 0.20, 0.30, 0.0,kTheta_x, kTheta_y, kTheta_z) 
     )
 

--- a/api_python/102-Movement_high_level/05-Cartesian_waypoint_trajectory.py
+++ b/api_python/102-Movement_high_level/05-Cartesian_waypoint_trajectory.py
@@ -156,7 +156,6 @@ def example_trajectory(base: BaseClient):
     
     #Add waypoints to waypoint list
     wptlist.waypoints.MergeFrom(array_wpts)
-    wptlist.duration = 60 # in seconds
     result = base.ValidateWaypointList(wptlist)
 
     # If the list is valid, execute the waypoint list. If not, print an error

--- a/api_python/102-Movement_high_level/06-Angular_waypoint_trajectory.py
+++ b/api_python/102-Movement_high_level/06-Angular_waypoint_trajectory.py
@@ -118,7 +118,7 @@ def example_angular_trajectory(base):
     waypointsDefinition = [
         ([40, -22, 75, 0, 10, 20], 1),
         ([40, -20, 70, 0, 11, 21], 1),
-        ([40, -22, 75, 0, 10, 20], 1),
+        ([40, -22, 75, 0, 10, 20], 0),
     ]
 
     # Create a WaypointList to hold the waypoints

--- a/api_python/102-Movement_high_level/06-Angular_waypoint_trajectory.py
+++ b/api_python/102-Movement_high_level/06-Angular_waypoint_trajectory.py
@@ -92,10 +92,10 @@ def example_move_to_home_position(base, program_runner):
 # This function populates an Angular waypoint object with the data provided by an array
 def populate_angular_coordinates(waypointInformation):
     """
-    Populate AngularWaypoint message with provided angular coordinates, duration, and blending.
+    Populate AngularWaypoint message with provided angular coordinates and blending.
 
     Args:
-        waypointInformation (tuple): Tuple containing angular coordinates (list), duration (float), and blending (float).
+        waypointInformation (tuple): Tuple containing angular coordinates (list), and blending (float).
 
     Returns:
         Base_pb2.AngularWaypoint: AngularWaypoint message populated with the provided information.
@@ -103,11 +103,10 @@ def populate_angular_coordinates(waypointInformation):
     waypoint = Base_pb2.AngularWaypoint()
 
     # Extract values from the tuple
-    angles_list, duration, blending = waypointInformation
+    angles_list, blending = waypointInformation
 
     # Populate AngularWaypoint fields
     waypoint.angles.extend(map(float, angles_list))  # Array of 6 angles, in degrees
-    waypoint.duration = duration  # Duration in seconds
     waypoint.blending = blending  # Blending factor, float from 0 to 1 (1 being optimal blending)
 
     return waypoint
@@ -115,11 +114,11 @@ def example_angular_trajectory(base):
     # Set the operating mode to AUTO
     change_operating_mode(base, "OPERATING_MODE_AUTO")
 
-    # Define waypoints with angles, duration, and blending values
+    # Define waypoints with angles and blending values
     waypointsDefinition = [
-        ([40, -22, 75, 0, 10, 20], 5, 1),
-        ([40, -20, 70, 0, 11, 21], 5, 1),
-        ([40, -22, 75, 0, 10, 20], 5, 1),
+        ([40, -22, 75, 0, 10, 20], 1),
+        ([40, -20, 70, 0, 11, 21], 1),
+        ([40, -22, 75, 0, 10, 20], 1),
     ]
 
     # Create a WaypointList to hold the waypoints
@@ -127,11 +126,11 @@ def example_angular_trajectory(base):
     wptlist.use_optimal_blending = True
 
     # Iterate over waypoints and add them to the WaypointList
-    for i, (angles, duration, blending) in enumerate(waypointsDefinition):
+    for i, (angles, blending) in enumerate(waypointsDefinition):
         waypoint = wptlist.waypoints.add()
         waypoint.name = f"waypoint_{i}"
         # Populate Angular waypoint coordinates using the provided function
-        waypoint.angular_waypoint.CopyFrom(populate_angular_coordinates((angles, duration, blending)))
+        waypoint.angular_waypoint.CopyFrom(populate_angular_coordinates((angles, blending)))
 
     # Validate the waypoint list
     result = base.ValidateWaypointList(wptlist)

--- a/api_python/README.md
+++ b/api_python/README.md
@@ -75,7 +75,7 @@ python3 --ip 192.168.2.22 <example-file>.py
 ```
 
 
-Before starting, ensure that you run the test in a safe area since some examples contain movement. Also, verify that your robot is correctly fixed to the working surface.
+**Before starting, ensure that you run the test in a safe area since some examples contain wide movements at full speed (default behaviour, but you can reduce speeds by modyfing the example code). Also, verify that your robot is correctly fixed to the working surface.**
 
 Prerequisites:
 + The examples require a wired network connection to your computer

--- a/readme.md
+++ b/readme.md
@@ -81,6 +81,7 @@ Before getting started, please review the release notes to learn about any limit
 
 | Firmware     | Release notes      | API |
 | :----------: | :-----------: | :-----------:|
+| [3.3.0](https://artifactory.kinovaapps.com/ui/native/generic-local-public/kortex/link6/3.3.0/link6-3.3.0-r.6.swu) | [release notes](https://artifactory.kinovaapps.com:443/artifactory/generic-documentation-public/Documentation/Link%206/Technical%20documentation/User%20Guide/EN-eRN-020-Link-6-release-notes.pdf) | [3.3.0](https://artifactory.kinovaapps.com/ui/native/generic-public/kortex/API/3.3.0/kortex_api-3.3.0.2-py3-none-any.whl)|
 | [3.2.0](https://artifactory.kinovaapps.com:443/artifactory/generic-local-public/kortex/link6/3.2.0/link6-3.2.0-r.38.swu)   | [release notes](https://artifactory.kinovaapps.com:443/artifactory/generic-documentation-public/Documentation/Link%206/Technical%20documentation/User%20Guide/EN-eRN-020-Link-6-release-notes.pdf)    | [3.2.0](https://artifactory.kinovaapps.com/artifactory/generic-public/kortex/API/3.2.0/kortex_api-3.2.0.9-py3-none-any.whl)|
 
 </details>


### PR DESCRIPTION
The robot's base ignores the `duration` field when processing waypoints, so the setting of this value was removed from the examples while this is fixed in the API